### PR TITLE
Refactor with args Dictionary and a few more

### DIFF
--- a/addons/dragonforge_state_machine/state.gd
+++ b/addons/dragonforge_state_machine/state.gd
@@ -102,11 +102,5 @@ func remove_arg(arg: StringName) -> void:
 ## Returns an argument [param arg] from the [member StateMachine._args]
 ## [Dictionary], or [code]false[/code] if the argument doesn't exist
 ## in the [member StateMachine._args].
-func get_arg(arg: StringName) -> bool:
+func is_arg(arg: StringName) -> bool:
 	return _state_machine.get_arg(arg)
-
-
-## Returns [code]true[/code] or [code]false[/code] respectively if an argument
-## [param arg] exists in the [member StateMachine._args] [Dictionary].
-func has_arg(arg: StringName) -> bool:
-	return _state_machine.has_arg(arg)

--- a/addons/dragonforge_state_machine/state_machine.gd
+++ b/addons/dragonforge_state_machine/state_machine.gd
@@ -185,11 +185,5 @@ func remove_arg(arg: StringName) -> void:
 
 ## Returns an argument [param arg] from the [member _args] [Dictionary],
 ## or [code]false[/code] if the argument doesn't exist in the [member _args].
-func get_arg(arg: StringName) -> bool:
+func is_arg(arg: StringName) -> bool:
 	return _args.get(arg, false)
-
-
-## Returns [code]true[/code] or [code]false[/code] respectively if an argument
-## [param arg] exists in the [member _args] [Dictionary].
-func has_arg(arg: StringName) -> bool:
-	return _args.has(arg)


### PR DESCRIPTION
Hi @dragonforge-dev
After playing around with your StateMachine, I decided to clean up the code a bit and make it a PR here. I added a couple of functionalities to the StateMachine that we discussed about on the Godot Forum, plus a couple more.

1. `_args` Dictionary that allows communication between States without breaking any dependency, can be used by calling one of these directly from the State:
    * `set_arg()`
    * `remove_arg()`
    * `get_arg()`
    * `has_arg()`
2. Possibility to easily add and remove States with methods called directly on the StateMachine:
    * `add_state()`
    * `remove_state()`
3. `state_changed` signal that is called when a State is changed, allows for less frequent checks that currently sometimes have to be called in `_process()` due to no better alternative. Now that I wrote that I think it could also be a nice addition to emit a signal when the current state sets `can_transition = true`, so that states can check for this signal and validate it against their state entering conditions, instead of in the `_process()`. That could be a signal on the StateMachine itself that the States just connect to once, and the StateMachine reconnects the signals depending on which the current state is. I'll test it around and maybe create a new PR then for that.
4. `autostart` flag that can be turned off, if the StateMachine shouldn't start automatically. Handy when you have an Inherited Scene including a StateMachine, because you can't remove Nodes from Inherited Scenes, but you can still change their parameters. If you want to disable a certain StateMachine on the Inherited Scene, you can then just set the `autostart` flag to false. Without this flag, it is currently impossible to turn off a certain StateMachine on an Inherited Scene.
5. `print_state_changes` that you can turn off to make the console shut up once you're done testing the StateMachine.

All of these changes shouldn't break anything in the existing StateMachines, all the defaults are set to work exactly the same as the original one. This PR just adds functionality on top.