### PR TITLE
StateMachine start/stop refactor

### DIFF
--- a/addons/dragonforge_state_machine/state.gd
+++ b/addons/dragonforge_state_machine/state.gd
@@ -73,7 +73,6 @@ func _activate_state() -> void:
 ## [br]When overriding, be sure to call [method super] on the first line of your method.
 ## [br][i]Never[/i] call this method directly. It should only be used by the [StateMachine]
 func _deactivate_state() -> void:
-	if not is_activated: return
 	is_activated = false
 	if _state_machine.print_state_changes:
 		print_rich("[color=#d42c2a][b]Deactivate[/b][/color] [color=gold][b]%s[/b][/color] [color=ivory]%s State:[/color] [color=#d42c2a]%s[/color]" % [_subject_name, _state_machine_name, self.name])

--- a/addons/dragonforge_state_machine/state_machine.gd
+++ b/addons/dragonforge_state_machine/state_machine.gd
@@ -106,7 +106,7 @@ func stop() -> void:
 		_current_state._exit_state() # Run the exit code for the current state. (Even if the state says you can't exit it.)
 	
 	for state in get_children():
-		if state is State:
+		if state is State and state.is_activated:
 			state._deactivate_state()
 
 
@@ -165,7 +165,8 @@ func add_state(state: State) -> void:
 ## and immediately deactivates it.
 func remove_state(state: State) -> void:
 	if state.get_parent() == self:
-		state._deactivate_state()
+		if state.is_activated:
+			state._deactivate_state()
 		remove_child(state)
 
 


### PR DESCRIPTION
This PR covers changes mentioned in #3, additionally refactoring the `StateMachine`'s ability to properly `start` and `stop` at runtime, properly deactivating and activating `State`s as necessary.

1. `initialize()` method is not required anymore, as states are activated in `start()` method instead.
2. The `child_entered_tree` and `child_exiting_tree` signals are not required, because activation and deactivation is handled in `add_state()` and `remove_state()` respectively. This essentially forces the user to always add and remove states with `add_state()` and `remove_state()` respectively instead of the built-in `add_child()` and `remove_child()`. This is the controversial part that I think you won't like, but there is a reason to do it as such, I hope I'll be able to explain it here.
When we put `set_process(true)` in `_activate_state()`, we should put the opposite `set_process(false)` in the `_deactivate_state()`, because we want to stop the processing of the `State` when the `StateMachine` is stopped at runtime. Then let's assume we want to remove the `State` at runtime - doesn't matter if the `StateMachine` is stopped at this time or not.
For some reason, at the time the `child_exiting_tree` signal is emitted, the processing of this `Node` is already turned off by the engine, so when we try to `set_process(false)`, the engine will throw a soft error [on this line](https://github.com/godotengine/godot/blob/f62fdbde15035c5576dad93e586201f4d41ef0cb/scene/main/scene_tree.cpp#L1378). Nothing breaks, the execution continues, but there is this error that will probably just confuse the user.
The only solution to avoid that error that I can think of, is to move the `_deactivate_state()` call to be before the `State` is removed from the `SceneTree`. That's why I put it in the `remove_state()` method before the `remove_child()` is called, which fixes the problem.
Technicaly, adding state could stay as it was, because the issue is only with removing states. But that would just bring confusion why adding works, but removing not. This could be avoided by guiding the user to always use the dedicated `add_state()` and `remove_state()` when adding/removing states at runtime, which shouldn't be too much of a hassle. This change will also break existing `StateMachine`s, if they added/remove `State`s through code, so should be properly documented. 

With these changes, my `StateMachine` seems to work properly in all situations - adding and removing `State`s at runtime, as well as starting and stopping `StateMachine` at runtime.

This overall should bring performance benefit when the `StateMachine` is stopped as opposed to the original implementation, because states are now properly deactivated.

As mentioned on the Forum - I haven't had the time to update documentation yet, but I'll still try to do that tomorrow. 